### PR TITLE
Plugin supports multisite WP installs

### DIFF
--- a/inc/class-image-compression.php
+++ b/inc/class-image-compression.php
@@ -7,7 +7,23 @@ class Image_Compression {
 
     public function __construct() {
         //create tables
-        register_activation_hook(WPIC_FILE, array($this, 'wp_crush_activation'));
+        register_activation_hook(WPIC_FILE, array($this, 'on_activate'));
+    }
+
+    // Creating tables for all blogs in a WordPress Multisite installation
+    function on_activate( $network_wide ) {
+        global $wpdb;
+        if ( is_multisite() && $network_wide ) {
+            // Get all blogs in the network and activate plugin on each one
+            $blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+            foreach ( $blog_ids as $blog_id ) {
+                switch_to_blog( $blog_id );
+                $this->wp_crush_activation();
+                restore_current_blog();
+            }
+        } else {
+            $this->wp_crush_activation();
+        }
     }
 
     public static function wp_crush_activation() {

--- a/inc/class-image-compression.php
+++ b/inc/class-image-compression.php
@@ -8,6 +8,8 @@ class Image_Compression {
     public function __construct() {
         //create tables
         register_activation_hook(WPIC_FILE, array($this, 'on_activate'));
+        // Creating table whenever a new blog is created
+        add_action( 'wpmu_new_blog', 'on_create_blog', 10, 6 );
     }
 
     // Creating tables for all blogs in a WordPress Multisite installation
@@ -82,6 +84,15 @@ class Image_Compression {
         
         //cache/remove images
         Image_Functions::site_image_sizes_handling();
+    }
+
+    // Creating tables whenever a new blog is created
+    function on_create_blog( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
+        if ( is_plugin_active_for_network( 'plugin-name/plugin-name.php' ) ) {
+            switch_to_blog( $blog_id );
+            $this->wp_crush_activation();
+            restore_current_blog();
+        }
     }
 
 }

--- a/inc/class-image-compression.php
+++ b/inc/class-image-compression.php
@@ -10,6 +10,8 @@ class Image_Compression {
         register_activation_hook(WPIC_FILE, array($this, 'on_activate'));
         // Creating table whenever a new blog is created
         add_action( 'wpmu_new_blog', 'on_create_blog', 10, 6 );
+        // Deleting the table whenever a blog is deleted
+        add_filter( 'wpmu_drop_tables', 'on_delete_blog' );
     }
 
     // Creating tables for all blogs in a WordPress Multisite installation
@@ -93,6 +95,13 @@ class Image_Compression {
             $this->wp_crush_activation();
             restore_current_blog();
         }
+    }
+
+    // Deleting tables whenever a blog is deleted
+    function on_delete_blog( $tables ) {
+        global $wpdb;
+        $tables[] = $wpdb->prefix . 'table_name';
+        return $tables;
     }
 
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,8 +6,94 @@
  */
 defined('WP_UNINSTALL_PLUGIN') || exit;
 
-delete_option('wpic_api_key');
-delete_option('wpic_plan_data');
-delete_option('wpic_shop_identifier');
-delete_option('wpic_plan_next_charge');
-delete_option('compression_type');
+
+global $wpdb;
+
+
+// Delete tables for all blogs in a WordPress Multisite
+if ( is_multisite() ) {
+    // Get all blogs in the network and delete tables on each one
+	$offset = 0;
+	$limit  = 100;
+	while ( $blogs = $wpdb->get_results( "SELECT blog_id FROM {$wpdb->blogs} LIMIT $offset, $limit", ARRAY_A ) ) {
+		if ( $blogs ) {
+			foreach ( $blogs as $blog ) {
+		        switch_to_blog( $blog['blog_id'] );
+
+				delete_option( 'wpic_api_key' );
+				delete_option( 'wpic_plan_data' );
+				delete_option( 'wpic_shop_identifier' );
+				delete_option( 'wpic_plan_next_charge' );
+				delete_option( 'compression_type' );
+				delete_site_option( 'wpic_api_key' );
+				delete_site_option( 'wpic_plan_data' );
+				delete_site_option( 'wpic_shop_identifier' );
+				delete_site_option( 'wpic_plan_next_charge' );
+				delete_site_option( 'compression_type' );
+
+				// Delete plugin tables on uninstall
+				$crush_image_actions = $wpdb->prefix . 'crush_image_actions';
+				$crush_image_all_sizes = $wpdb->prefix . 'crush_image_all_sizes';
+				$crush_image_sizes = $wpdb->prefix . 'crush_image_sizes';
+
+				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_actions}" );
+				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_all_sizes}" );
+				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_sizes}" );
+
+				// Delete backups
+				$upload_dir = wp_upload_dir();
+				$backup_dir = $upload_dir['basedir'] . '/crushed-backup/';
+
+				if( is_dir( $backup_dir ) ) {
+					$it = new RecursiveDirectoryIterator( $backup_dir, RecursiveDirectoryIterator::SKIP_DOTS );
+					$files = new RecursiveIteratorIterator( $it,
+					             RecursiveIteratorIterator::CHILD_FIRST );
+					foreach( $files as $file ) {
+					    if ( $file->isDir() ){
+					        rmdir( $file->getRealPath() );
+					    } else {
+					        unlink( $file->getRealPath() );
+					    }
+					}
+					rmdir( $backup_dir );
+				}
+		    }
+			restore_current_blog();
+		}
+		$offset += $limit;
+	}
+} else {
+
+	delete_option( 'wpic_api_key' );
+	delete_option( 'wpic_plan_data' );
+	delete_option( 'wpic_shop_identifier' );
+	delete_option( 'wpic_plan_next_charge' );
+	delete_option( 'compression_type' );
+
+	// Delete plugin tables on uninstall
+	$crush_image_actions = $wpdb->prefix . 'crush_image_actions';
+	$crush_image_all_sizes = $wpdb->prefix . 'crush_image_all_sizes';
+	$crush_image_sizes = $wpdb->prefix . 'crush_image_sizes';
+
+	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_actions}" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_all_sizes}" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_sizes}" );
+
+	// Delete backups
+	$upload_dir = wp_upload_dir();
+	$backup_dir = $upload_dir['basedir'] . '/crushed-backup/';
+
+	if( is_dir( $backup_dir ) ) {
+		$it = new RecursiveDirectoryIterator( $backup_dir, RecursiveDirectoryIterator::SKIP_DOTS );
+		$files = new RecursiveIteratorIterator( $it,
+		             RecursiveIteratorIterator::CHILD_FIRST );
+		foreach( $files as $file ) {
+		    if ( $file->isDir() ){
+		        rmdir( $file->getRealPath() );
+		    } else {
+		        unlink( $file->getRealPath() );
+		    }
+		}
+		rmdir( $backup_dir );
+	}
+}


### PR DESCRIPTION
When activating the plugin:
- Create separate tables for each multisite if they have not been created before.

When uninstalling the plugin:
- Delete backups for each multisite.
- Delete tables for each multisite.
- Delete options for each multisite.

Other enhancements:
- Creating tables whenever a new blog is created.
- Deleting tables whenever a blog is deleted.