### PR TITLE
Support for large images in WordPress 5.3

### DIFF
--- a/image-compression.php
+++ b/image-compression.php
@@ -1,10 +1,10 @@
 <?php
 
 /**
- * Plugin Name: Crush.pics - Image Compression and Optimization
+ * Plugin Name: Crush.pics Image Optimizer – Image Compression and Optimization
  * Plugin URI: https://crush.pics/platforms/wordpress-plugin
  * Description: Image Compression and Optimization using Crush.pics API
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: Space Squirrel Ltd.
  * Author URI: https://crush.pics
  * Text Domain: crush-pics-image-compression-optimization
@@ -18,7 +18,7 @@ if (!defined('ABSPATH'))
 define('WPIC_URL', plugin_dir_url(__FILE__));
 define('WPIC_PATH', plugin_dir_path(__FILE__));
 define('WPIC_FILE', __FILE__);
-define('WPIC_VERSION', '1.8.1');
+define('WPIC_VERSION', '1.8.2');
 
 //main class
 require_once WPIC_PATH . 'inc/class-image-compression.php';

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -267,11 +267,11 @@
 
                                                     <button class="btn btn-secondary btn-sm w-100 wp_image_compress" style="display:none;" data-guid="" data-id="" data-size="full"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
 
-                                                    <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $image->guid; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
+                                                    <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
 
                                                 <?php } elseif (empty($image->status) || (!empty($image->status) && ($image->status == 'restored' || $image->status == 'error' || $image->status == 'enqueued'))) { ?>
 
-                                                    <button class="btn btn-secondary btn-sm w-100 wp_image_compress" data-guid="<?php echo $image->guid; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($image->action) ? $image->action : ''; ?>"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
+                                                    <button class="btn btn-secondary btn-sm w-100 wp_image_compress" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($image->action) ? $image->action : ''; ?>"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
 
                                                     <button class="btn btn-secondary btn-sm w-100 wp_image_restore" style="display:none;" data-backup="" data-guid="" data-id="" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
 
@@ -437,11 +437,11 @@
 
                                                                         <button class="btn btn-secondary btn-sm w-100 wp_image_compress" style="display:none;" data-guid="" data-id="" data-size="full"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
 
-                                                                        <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $image->guid; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
+                                                                        <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
 
                                                                     <?php } elseif (empty($image->status) || (!empty($image->status) && ($image->status == 'restored' || $image->status == 'error' || $image->status == 'enqueued'))) { ?>
 
-                                                                        <button class="btn btn-secondary btn-sm w-100 wp_image_compress" data-guid="<?php echo $image->guid; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($image->action) ? $image->action : ''; ?>"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
+                                                                        <button class="btn btn-secondary btn-sm w-100 wp_image_compress" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $image->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($image->action) ? $image->action : ''; ?>"  type="button"><?php _e('Compress', 'wp-image-compression'); ?></button>
 
                                                                         <button class="btn btn-secondary btn-sm w-100 wp_image_restore" style="display:none;" data-backup="" data-guid="" data-id="" data-size="full" ><?php _e('Restore', 'wp-image-compression'); ?></button>
 

--- a/inc/views/media-list.php
+++ b/inc/views/media-list.php
@@ -93,17 +93,19 @@ $data_backup = '';
 if (!empty($img_details->backup_image))
     $data_backup = $img_details->backup_image;
 
+$full_size_media_image = wp_get_attachment_image_src( $img_details->ID, 'full' );
+
 
 if (!empty($img_details->status) && $img_details->status == 'crushed' && !empty($data_backup) && !empty($compression_backup)):
     ?>
 
     <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" style="display:none;" data-guid="" data-id="" data-size="full"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush', 'wp-image-compression'); ?></button>
 
-    <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $img_details->guid; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
+    <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
 
 <?php elseif (empty($img_details->status) || (!empty($img_details->status) && ($img_details->status == 'restored' || $img_details->status == 'error' || $img_details->status == 'enqueued'))): ?>
 
-    <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" data-guid="<?php echo $img_details->guid; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($img_details->action) ? $img_details->action : ''; ?>"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush', 'wp-image-compression'); ?></button>
+    <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($img_details->action) ? $img_details->action : ''; ?>"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush', 'wp-image-compression'); ?></button>
 
     <button class="btn btn-secondary btn-sm w-100 wp_image_restore" style="display:none;" data-backup="" data-guid="" data-id="" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
 

--- a/inc/views/single-media-page.php
+++ b/inc/views/single-media-page.php
@@ -49,17 +49,19 @@ if ($quota_usage >= $bytes) {
     if (!empty($img_details->backup_image))
         $data_backup = $img_details->backup_image;
 
+    $full_size_media_image = wp_get_attachment_image_src( $img_details->ID, 'full' );
+
 
     if (!empty($img_details->status) && $img_details->status == 'crushed' && !empty($data_backup) && !empty($compression_backup)):
         ?>
 
         <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" style="display:none;" data-guid="" data-id="" data-size="full"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush image', 'wp-image-compression'); ?></button>
 
-        <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $img_details->guid; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
+        <button class="btn btn-secondary btn-sm w-100 wp_image_restore" data-backup="<?php echo $data_backup; ?>" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
 
     <?php elseif (empty($img_details->status) || (!empty($img_details->status) && ($img_details->status == 'restored' || $img_details->status == 'error' || $img_details->status == 'enqueued'))): ?>
 
-        <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" data-guid="<?php echo $img_details->guid; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($img_details->action) ? $img_details->action : ''; ?>"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush image', 'wp-image-compression'); ?></button>
+        <button class="btn btn-secondary btn-sm w-100 wp_image_compress main-card-container" data-guid="<?php echo $full_size_media_image[0]; ?>" data-id="<?php echo $img_details->ID; ?>" data-size="full" data-status="<?php echo $action = !empty($img_details->action) ? $img_details->action : ''; ?>"  type="button" data-upgrade = <?php echo $upgrade_plan; ?>><?php _e('Crush image', 'wp-image-compression'); ?></button>
 
         <button class="btn btn-secondary btn-sm w-100 wp_image_restore" style="display:none;" data-backup="" data-guid="" data-id="" data-size="full" type="button" ><?php _e('Restore original', 'wp-image-compression'); ?></button>
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== Crush.pics – Image Compression and Optimization ===
+=== Crush.pics Image Optimizer – Image Compression and Optimization ===
 Contributors: crushpics
-Tags: optimize images, images, optimize, compress, compress images, performance, crush, compression, optimization
+Tags: image optimizer, optimizer, optimize images, images, optimize, compress, compress images, performance, crush, compression, optimization
 Requires at least: 4.0.0
 Tested up to: 5.3
 Stable tag: 1.7.8


### PR DESCRIPTION
All links for "Compression" and "Restore" have been replaced by the correct ones