### PR TITLE
On expanding details, filename replaced

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1031,6 +1031,10 @@ a.btn, a.btn:hover {
     max-width: 300px;
 }
 
+.dashboard-tip {
+    margin: 0;
+}
+
 .images_table_container #all-images-list li span.border-right {
     border-right: 0px !important;
 }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -516,6 +516,24 @@ jQuery(document).ready(function ($) {
         }
     });
 
+    // Replace image name
+    $( document ).on( 'click', '.main-details-btn', function () {
+        var button = $( this );
+        var previewLink = button.closest( "tr" ).find( '.image-preview-link' );
+        if ( previewLink.is( ':visible' ) ) {
+            button.closest( "tr" ).find( '.dashboard-image-toggle' ).hide().next().show();
+        }
+    } );
+
+    // Show image name
+    $( document ).on( 'click', '.main-close-btn', function () {
+        var button = $( this );
+        var previewLink = button.closest( "tr" ).find( '.image-preview-link' );
+        if ( previewLink.is( ':visible' ) ) {
+            button.closest( "tr" ).find( '.dashboard-tip' ).hide().parent().find( '.dashboard-image-toggle' ).show();
+        }
+    } );
+
     //hide image details
     $(document).on('click', '.image_close', function () {
         var button = $(this);

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -465,6 +465,7 @@ jQuery(document).ready(function ($) {
                     button.closest('tr').find('.wp_image_compress').attr('data-id', data.image_id);
                     button.closest('tr').find('.wp_image_compress').attr('data-status', 'restored');
                     button.closest('tr').find('.wp_image_compress').attr('data-size', size);
+                    button.closest( 'tr' ).find( '.dashboard-tip' ).hide().parent().find( '.dashboard-image-toggle' ).show();
                     if (size == 'full') {
                         $('tr.parent-details-banner-' + id).find('.restored-status').css('display', 'inline-flex');
                         $('tr.parent-details-banner-' + id).find('.wp_image_compress').show();
@@ -521,7 +522,7 @@ jQuery(document).ready(function ($) {
         var button = $( this );
         var previewLink = button.closest( "tr" ).find( '.image-preview-link' );
         if ( previewLink.is( ':visible' ) ) {
-            button.closest( "tr" ).find( '.dashboard-image-toggle' ).hide().next().show();
+            button.closest( 'tr' ).find( '.dashboard-image-toggle' ).hide().next().show();
         }
     } );
 
@@ -530,7 +531,7 @@ jQuery(document).ready(function ($) {
         var button = $( this );
         var previewLink = button.closest( "tr" ).find( '.image-preview-link' );
         if ( previewLink.is( ':visible' ) ) {
-            button.closest( "tr" ).find( '.dashboard-tip' ).hide().parent().find( '.dashboard-image-toggle' ).show();
+            button.closest( 'tr' ).find( '.dashboard-tip' ).hide().parent().find( '.dashboard-image-toggle' ).show();
         }
     } );
 
@@ -702,11 +703,15 @@ function check_compress(crushed_id, button) {
                             jQuery('tr.parent-details-banner-' + data.image_id).find('.crushed-status').css('display', 'inline-flex');
                         }
                         if (data.backup == 'yes') {
+                            var mainCloseBtn = button.closest( 'tr' ).find( '.main-close-btn' );
                             button.closest('tr').find('.wp_image_restore').show();
                             button.closest('tr').find('.restored-status').hide();
                             button.closest('tr').find('.wp_image_restore').attr('data-backup', data.image_backup_path);
                             button.closest('tr').find('.wp_image_restore').attr('data-guid', data.image_url);
                             button.closest('tr').find('.wp_image_restore').attr('data-id', data.image_id);
+                            if ( mainCloseBtn.is( ':visible' ) ) {
+                                button.closest( 'tr' ).find( '.dashboard-image-toggle' ).hide().next().show();
+                            }
                             if (data.image_size == 'full') {
                                 jQuery('tr.parent-details-banner-' + data.image_id).find('.wp_image_restore').show();
                                 jQuery('tr.parent-details-banner-' + data.image_id).find('.restored-status').hide();
@@ -722,12 +727,12 @@ function check_compress(crushed_id, button) {
                                 jQuery('tr.parent-details-banner-' + data.image_id).find('.saved-image').css('display', 'inline-flex');
                                 jQuery('tr.parent-details-banner-' + data.image_id).find('.saved-image').text(data.saved);
                                 if ( data.backup == 'yes' ) {
-                                    jQuery('tr.parent-details-banner-' + data.image_id).find('.image-preview-link').attr({
+                                    jQuery( 'tr.parent-details-banner-' + data.image_id ).find( '.image-preview-link' ).attr( {
                                         "data-before" : data.image_url,
                                         "data-after" : data.upload_dir + data.image_backup_path,
-                                    });
-                                    jQuery('tr.parent-details-banner-' + data.image_id).find('.image-item').hide();
-                                    jQuery('tr.parent-details-banner-' + data.image_id).find('.image-preview-link').css('display', 'inline-flex');
+                                    } );
+                                    jQuery( 'tr.parent-details-banner-' + data.image_id ).find( '.image-item' ).hide();
+                                    jQuery( 'tr.parent-details-banner-' + data.image_id ).find( '.image-preview-link' ).css( 'display', 'inline-flex' );
                                 }
                             }
                         }

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -185,7 +185,7 @@
                                                 ?>
 
                                                 <span class="text-muted align-middle dashboard-image-name dashboard-image-toggle"><?php echo $full_image_name; ?></span>
-                                                <span class="text-uppercase h5 text-muted font-weight-bold dashboard-tip" style="display: none;"><?php _e( 'CLICK THUMBNAIL TO SEE THE IMAGE', 'wp-image-compression' ); ?></span>
+                                                <span class="text-uppercase h5 text-muted font-weight-bold dashboard-tip" style="display: none;"><?php _e( 'Click thumbnail to see the image', 'wp-image-compression' ); ?></span>
 
                                         </div>
 

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -185,7 +185,7 @@
                                                 ?>
 
                                                 <span class="text-muted align-middle dashboard-image-name dashboard-image-toggle"><?php echo $full_image_name; ?></span>
-                                                <span class="text-muted align-middle dashboard-image-name dashboard-tip" style="display: none;"><?php _e( 'CLICK THUMBNAIL TO SEE THE IMAGE', 'wp-image-compression' ); ?></span>
+                                                <span class="text-uppercase h5 text-muted font-weight-bold dashboard-tip" style="display: none;"><?php _e( 'CLICK THUMBNAIL TO SEE THE IMAGE', 'wp-image-compression' ); ?></span>
 
                                         </div>
 

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -184,7 +184,8 @@
                                                 //($image->status == 'error' && $has_restored && !empty($compression_backup) )
                                                 ?>
 
-                                                <span class="text-muted align-middle dashboard-image-name"><?php echo $full_image_name; ?></span>
+                                                <span class="text-muted align-middle dashboard-image-name dashboard-image-toggle"><?php echo $full_image_name; ?></span>
+                                                <span class="text-muted align-middle dashboard-image-name dashboard-tip" style="display: none;"><?php _e( 'CLICK THUMBNAIL TO SEE THE IMAGE', 'wp-image-compression' ); ?></span>
 
                                         </div>
 
@@ -287,9 +288,9 @@
 
                                             <div class=" px-1 mb-0 my-lg-2 crush_action">
 
-                                                <button class="btn btn-secondary btn-sm w-100 image_details" data-size="full" data-id="<?php echo $image->ID; ?>"><?php _e('Details', 'wp-image-compression'); ?></button>
+                                                <button class="btn btn-secondary btn-sm w-100 image_details main-details-btn" data-size="full" data-id="<?php echo $image->ID; ?>"><?php _e('Details', 'wp-image-compression'); ?></button>
 
-                                                <button class="btn btn-secondary btn-sm w-100 image_close" data-size="full" data-id="<?php echo $image->ID; ?>" style="display:none;"><?php _e('Close', 'wp-image-compression'); ?></button>
+                                                <button class="btn btn-secondary btn-sm w-100 image_close main-close-btn" data-size="full" data-id="<?php echo $image->ID; ?>" style="display:none;"><?php _e('Close', 'wp-image-compression'); ?></button>
 
                                             </div>
 


### PR DESCRIPTION
When expanding details of an image, if the image is compressed, there is an original image and a backup, the filename replaced with text "CLICK THUMBNAIL TO SEE THE IMAGE".