### PR TITLE
Images table when bulk compression running

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1121,13 +1121,14 @@ a.btn, a.btn:hover {
 
 .crush_all_container:after {
     content: '';
-    background-color: #ffffff80;
+    background-color: #ffffff;
     position: absolute;
     left: 0;
     right: 0;
     bottom: 0;
     top: 0;
     z-index: 999;
+    opacity: .92;
 }
 
 .vertical-divider {
@@ -1241,6 +1242,20 @@ textarea.api_key_value {
 }
 .validation-pop-email .validate-custom-screen .btn-outline-primary {
     margin-bottom: 55px;
+}
+.overlay-txt {
+    left: 50%;
+    top: 50%;
+    transform: translate( -50%, -50% );
+    max-width: 449px;
+    z-index: 1000;
+}
+.overlay-txt-header {
+    font-size: 20px;
+}
+.overlay-txt-p {
+    color: #637381;
+    font-size: 14px;
 }
 
 /* Crush.pics twentytwenty theme overwrite */

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -594,7 +594,7 @@ jQuery(document).ready(function ($) {
 
 
     });
-    if ($('.images_table_container').hasClass('crush_all_container')) {
+    if ( $( '.images-table' ).hasClass( 'crush_all_container' ) ) {
         $('.container-count-actions').removeClass('d-block').addClass('d-none');
         var crush_all_interval = setInterval(crush_all_check_status, 1000);
         $('.crush_all').attr('data-interval', crush_all_interval);
@@ -942,7 +942,7 @@ function fill_image_details(id, type, size) {
                     $('.un-crushed-images-no').html(data.un_crushed_images_no);
                     if (parseInt(data.un_crushed_images_no) > 0) {
                         $('.end_compress_container').hide(0, function () {
-                            if (!$('.images_table_container').hasClass('crush_all_container')) {
+                            if ( ! $( '.images-table' ).hasClass( 'crush_all_container' ) ) {
                                 $('.container-count-actions').removeClass('d-none').addClass('d-block');
                             }
                         });
@@ -1044,7 +1044,6 @@ function reload_image_table() {
             if (data) {
                 jQuery('.images_table_container').html('');
                 jQuery('.images_table_container').html(data);
-                jQuery('.images_table_container').toggleClass('crush_all_container');
                 jQuery( '.overlay-txt' ).hide();
                 update_quota_used_card();
 //                jQuery('.check_status').each(function () {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1045,6 +1045,7 @@ function reload_image_table() {
                 jQuery('.images_table_container').html('');
                 jQuery('.images_table_container').html(data);
                 jQuery('.images_table_container').toggleClass('crush_all_container');
+                jQuery( '.overlay-txt' ).hide();
                 update_quota_used_card();
 //                jQuery('.check_status').each(function () {
 //                    var row = jQuery(this);

--- a/inc/views/dashboard.php
+++ b/inc/views/dashboard.php
@@ -243,9 +243,9 @@
     </div>
 
     <!-- Start images -->
-    <?php $crush_all_class = $crush_all == 'yes' ? 'crush_all_container' : ''; ?>
+    <?php $crush_all_class = $crush_all == 'yes' ? ' crush_all_container' : ''; ?>
 
-    <section class="py-4 images_table_container <?php echo $crush_all_class; ?>">
+    <section class="py-4 images_table_container">
 
         <?php include WPIC_PATH . 'inc/views/image-list-template.php'; ?>
 

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -1,6 +1,6 @@
 <!-- Start ims list -->
 
-<ul class="list-group list-group-horizontal align-items-center" id="all-images-list">
+<ul class="list-group list-group-horizontal align-items-center counters-list<?php echo $crush_all == 'yes' ? ' d-none' : ''; ?>" id="all-images-list">
 
     <li>
 
@@ -1089,6 +1089,13 @@
             <?php } ?>
 
         </div>
+
+        <?php if ( $crush_all == 'yes' ): ?>
+            <div class="overlay-txt position-absolute text-center">
+                <p class="overlay-txt-header"><?php _e( 'Crushing all images…', 'wp-image-compression' ); ?></p>
+                <p class="overlay-txt-p"><?php _e( 'Feel free to close the app any time during compression. We’ll keep working away in the background and then show full image details here once complete.', 'wp-image-compression' ); ?></p>
+            </div>
+        <?php endif ?>
 
     </div>
     <?php

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -56,7 +56,7 @@
 
     <div class="col-md-12">
 
-        <div class="card mw-100 py-0 px-0 card-top">
+        <div class="card mw-100 py-0 px-0 card-top images-table<?php echo $crush_all_class; ?>">
 
             <form method="get">
 
@@ -1080,6 +1080,12 @@
                     </table>
 
                 </div>
+                <?php if ( $crush_all == 'yes' ): ?>
+                <div class="overlay-txt position-absolute text-center">
+                    <p class="overlay-txt-header"><?php _e( 'Crushing all images…', 'wp-image-compression' ); ?></p>
+                    <p class="overlay-txt-p"><?php _e( 'Feel free to close the app any time during compression. We’ll keep working away in the background and then show full image details here once complete.', 'wp-image-compression' ); ?></p>
+                </div>
+                <?php endif ?>
             <?php } else { ?>
                 <div class="no-img-result"><img src="<?php echo WPIC_URL . 'assets/img/empty-results.svg'; ?>"/></div>
 
@@ -1089,13 +1095,6 @@
             <?php } ?>
 
         </div>
-
-        <?php if ( $crush_all == 'yes' ): ?>
-            <div class="overlay-txt position-absolute text-center">
-                <p class="overlay-txt-header"><?php _e( 'Crushing all images…', 'wp-image-compression' ); ?></p>
-                <p class="overlay-txt-p"><?php _e( 'Feel free to close the app any time during compression. We’ll keep working away in the background and then show full image details here once complete.', 'wp-image-compression' ); ?></p>
-            </div>
-        <?php endif ?>
 
     </div>
     <?php
@@ -1140,7 +1139,7 @@
             if (!empty($page_links)) {
                 ?>
 
-                <ul class="pagination justify-content-center">
+                <ul class="pagination justify-content-center<?php echo $crush_all_class; ?>">
 
                     <li class="page-item first">
 


### PR DESCRIPTION
Before that, when bulk compress was running, there was just a white overlay on the images table. It was unclear to the user why this is.

The text now appears on top, explaining what is happening. And the counters are hidden.