### PR TITLE
Rebuild/optimize to reduce database queries to support large sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 /vendor
 .DS_Store
+
+.idea/

--- a/inc/class-admin-menu.php
+++ b/inc/class-admin-menu.php
@@ -59,18 +59,16 @@ class Image_Compression_Menu {
         if ($api_key) {
 
             $crush_image_actions_table = $wpdb->prefix . 'crush_image_actions';
-            $table_image_sizes = $wpdb->prefix . 'crush_image_sizes';
             //total images count and crushed images count
             $enabled_sizes = get_option('compression_sizes');
-            if (!$enabled_sizes)
-                $enabled_sizes = array('full');
+            if ( ! $enabled_sizes )
+	            $enabled_sizes = array( 'full' );
             else
-                $enabled_sizes[] = 'full';
+            	$enabled_sizes[] = 'full';
 
-            $images_count = $wpdb->get_row('select count(id) as images_count from ' . $table_image_sizes . ' where image_size in ("' . implode('", "', $enabled_sizes) . '")');
-            if ($images_count)
-                $images_count = $images_count->images_count;
-
+	        $sql = "SELECT pm.post_id, pm.meta_value FROM $wpdb->postmeta pm
+				WHERE pm.meta_key = '_wp_attachment_metadata'";
+	        $images_count = Image_Functions::get_images_count( $enabled_sizes, $sql );
 
             $crushed_images_count = $wpdb->get_row('select count(id) as crushed_images_count from ' . $crush_image_actions_table . ' where action IN ("crushed","error") and is_history = 0 and image_size in ("' . implode('", "', $enabled_sizes) . '")');
             if ($crushed_images_count)
@@ -91,16 +89,7 @@ class Image_Compression_Menu {
 
             //get user plan data
             $plan_data = get_option('wpic_plan_data');
-            $crush_next_charge = get_option('wpic_plan_next_charge');
-            $next_charge_days = '-';
-            if ($crush_next_charge) {
-                $today = new DateTime();
-                $today->setTimestamp(current_time('timestamp'));
-                $crush_next_charge = new DateTime($crush_next_charge);
-                $next_charge_days = $crush_next_charge->diff($today)->days;
-
-                $next_charge_days = sprintf(_n('%s Day', '%s Days', $next_charge_days, 'wp-image-compression'), $next_charge_days);
-            }
+	        $next_charge_days = Image_Functions::get_next_charge_days();
             $quota_usage = 0;
             $bytes = 0;
             $plan_name = '';

--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -240,20 +240,17 @@ class Image_Compression_Ajax {
     function wpic_reload_image_table() {
         ob_start();
         global $wpdb;
-        //check if api activated
         $crush_image_actions_table = $wpdb->prefix . 'crush_image_actions';
-        $table_image_sizes = $wpdb->prefix . 'crush_image_sizes';
         //total images count and crushed images count
         $enabled_sizes = get_option('compression_sizes');
-        if (!$enabled_sizes)
-            $enabled_sizes = array('full');
-        else
-            $enabled_sizes[] = 'full';
+	    if ( ! $enabled_sizes )
+		    $enabled_sizes = array( 'full' );
+	    else
+		    $enabled_sizes[] = 'full';
 
-        $images_count = $wpdb->get_row('select count(id) as images_count from ' . $table_image_sizes . ' where image_size in ("' . implode('", "', $enabled_sizes) . '")');
-        if ($images_count)
-            $images_count = $images_count->images_count;
-
+	    $sql = "SELECT pm.post_id, pm.meta_value FROM $wpdb->postmeta pm
+				WHERE pm.meta_key = '_wp_attachment_metadata'";
+	    $images_count = Image_Functions::get_images_count( $enabled_sizes, $sql );
 
         $crushed_images_count = $wpdb->get_row('select count(id) as crushed_images_count from ' . $crush_image_actions_table . ' where action IN ("crushed","error") and is_history = 0 and image_size in ("' . implode('", "', $enabled_sizes) . '")');
         if ($crushed_images_count)
@@ -271,16 +268,7 @@ class Image_Compression_Ajax {
         $images = Image_Functions::list_all_full_image($image_term, $offset, $limit);
         //get user plan data
         $plan_data = get_option('wpic_plan_data');
-        $crush_next_charge = get_option('wpic_plan_next_charge');
-        $next_charge_days = '-';
-        if ($crush_next_charge) {
-            $today = new DateTime();
-            $today->setTimestamp(current_time('timestamp'));
-            $crush_next_charge = new DateTime($crush_next_charge);
-            $next_charge_days = $crush_next_charge->diff($today)->days;
-
-            $next_charge_days = sprintf(_n('%s Day', '%s Days', $next_charge_days, 'wp-image-compression'), $next_charge_days);
-        }
+	    $next_charge_days = Image_Functions::get_next_charge_days();
         $quota_usage = round($plan_data['quota_usage'] / 1000000, 2);
         $bytes = round($plan_data['bytes'] / 1000000, 2);
         $quota_usage_precentage = '';

--- a/inc/class-image-compression.php
+++ b/inc/class-image-compression.php
@@ -64,19 +64,6 @@ class Image_Compression {
 		) $charset_collate;";
             dbDelta($sql);
         }
-        //image sizes table
-        $table_image_sizes = $wpdb->prefix . 'crush_image_sizes';
-        if ($wpdb->get_var("SHOW TABLES LIKE '$table_image_sizes'") != $table_image_sizes) {
-            $sql = "CREATE TABLE " . $table_image_sizes . " (
-                        `id` bigint(20) NOT NULL AUTO_INCREMENT,
-			`image_id` bigint(20) NOT NULL,
-                        `image_size` varchar(255) NOT NULL,
-                        `image_size_path` varchar(255) NULL DEFAULT '',
-                        `image_file_size` varchar(255) NULL DEFAULT '',                        
-			PRIMARY KEY (`id`)
-		) $charset_collate;";
-            dbDelta($sql);
-        }
         //image crush all sizes table
         $table_crush_image_all_sizes = $wpdb->prefix . 'crush_image_all_sizes';
         if ($wpdb->get_var("SHOW TABLES LIKE '$table_crush_image_all_sizes'") != $table_crush_image_all_sizes) {
@@ -90,9 +77,6 @@ class Image_Compression {
 		) $charset_collate;";
             dbDelta($sql);
         }
-        
-        //cache/remove images
-        Image_Functions::site_image_sizes_handling();
     }
 
     // Creating tables whenever a new blog is created

--- a/inc/class-image-process.php
+++ b/inc/class-image-process.php
@@ -30,9 +30,6 @@ class Image_Process {
                     }
                 }
             }
-            //delete image sizes from image sizes table
-            $image_sizes_table = $wpdb->prefix . 'crush_image_sizes';
-            $wpdb->delete($image_sizes_table, array('image_id' => $post_id));
             //delete image sizes from image action table
             $crush_image_actions_table = $wpdb->prefix . 'crush_image_actions';
             $wpdb->delete($crush_image_actions_table, array('image_id' => $post_id));
@@ -41,11 +38,7 @@ class Image_Process {
 
     public function regenerate_image_sizes($data, $attachment_id) {
         if (!empty($data)) {
-            global $wpdb;
             $sql_data = Image_Functions::insert_image_sizes($attachment_id, $data);
-            if (!empty($sql_data) && !empty($sql_data['sql'])) {
-                $wpdb->query($sql_data['sql']);
-            }
             if (!empty($sql_data) && !empty($sql_data['sizes'])) {
                 $old_crushed_sizes = Image_Functions::get_image_crushed_sizes($attachment_id);
                 foreach ($sql_data['sizes'] as $size => $image_url) {

--- a/inc/views/image-list-template.php
+++ b/inc/views/image-list-template.php
@@ -509,7 +509,7 @@
 
                                                                 <h2 class="card-title display-d original_size_value card-details-title"><?php
                                                                     echo Image_Functions::format_size_units($original_size);
-                                                                    ?></h4>
+                                                                    ?></h2>
 
                                                                     <p class="card-text card-details-text">
 
@@ -919,7 +919,7 @@
 
                                                                         <h2 class="card-title display-d original_size_value card-details-title"><?php
                                                                             echo Image_Functions::format_size_units($item_original_size);
-                                                                            ?></h4>
+                                                                            ?></h2>
 
                                                                             <p class="card-text card-details-text">
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -53,11 +53,9 @@ if ( is_multisite() ) {
 				// Delete plugin tables on uninstall
 				$crush_image_actions = $wpdb->prefix . 'crush_image_actions';
 				$crush_image_all_sizes = $wpdb->prefix . 'crush_image_all_sizes';
-				$crush_image_sizes = $wpdb->prefix . 'crush_image_sizes';
 
 				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_actions}" );
 				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_all_sizes}" );
-				$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_sizes}" );
 
 				// Delete backups
 				$upload_dir = wp_upload_dir();
@@ -111,11 +109,9 @@ if ( is_multisite() ) {
 	// Delete plugin tables on uninstall
 	$crush_image_actions = $wpdb->prefix . 'crush_image_actions';
 	$crush_image_all_sizes = $wpdb->prefix . 'crush_image_all_sizes';
-	$crush_image_sizes = $wpdb->prefix . 'crush_image_sizes';
 
 	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_actions}" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_all_sizes}" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$crush_image_sizes}" );
 
 	// Delete backups
 	$upload_dir = wp_upload_dir();


### PR DESCRIPTION
- Rebuild/optimize to reduce database queries to support large sites with 15,000+ images.
- Delete one of the tables created by the plugin - resulting in less database load.
- Delete unnecessary functions.
- Rebuild some functions to reduce the size of the plugin according to best practices of OOP.
- Other fixes.